### PR TITLE
Add workflow for PR preview deployments

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,27 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1.6.2
+        with:
+          source-dir: .


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy PR previews using rossjrw/pr-preview-action
- configure concurrency, permissions, and repo-only guard for pull request events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc2b7f5c00832ab98aaa6c7b82a2ad